### PR TITLE
Use beaker tags to enhance menu items/actions

### DIFF
--- a/vmpooler-bitbar.30s.rb
+++ b/vmpooler-bitbar.30s.rb
@@ -65,6 +65,9 @@ vmpooler | <%= header_params %>
 -- Action | <%= submenu_header_params %>
 -- SSH to VM | href='ssh://root@<%= vm[:fqdn] %>' <%= terminal_action_params %>
 -- Delete VM | bash=<%= this_script %> param1=delete param2=<%= vm[:hostname] %> <%= refresh_action_params %>
+<%     if vm.key?(:pe_console) -%>
+-- Open PE Console | href='<%= vm[:pe_console] %>' <%= submenu_item_font_size %>
+<%     end                     -%>
 -----
 -- Extend Lifetime (<%= extend_lifetime_hours %>h) | bash=<%= this_script %> param1=extend param2=<%= vm[:hostname] %> <%= refresh_action_params %>
 -----
@@ -135,6 +138,9 @@ EOS
               vm[:tags] = details['tags']
               if vm[:tags].key?('name')
                 vm[:name] = vm[:tags]['name']
+              end
+              if vm[:tags].key?('roles') && vm[:tags]['roles'].include?('dashboard')
+                vm[:pe_console] = "https://#{vm[:fqdn]}"
               end
             end
           end

--- a/vmpooler-bitbar.30s.rb
+++ b/vmpooler-bitbar.30s.rb
@@ -61,7 +61,7 @@ vmpooler | <%= header_params %>
 <% if !vms.nil? -%>
 <%   vms.each do |vm| -%>
 <%     remaining_time_colour = vm[:remaining] <= warning_timeleft_threshhold ? 'red' : 'green' -%>
-<%= vm[:hostname] %> (<%= vm[:template] %>) | color=<%= remaining_time_colour %> <%= copy_menu_text_params(vm[:fqdn]) %>
+<%= vm[:hostname] %> (<%= vm[:name] %>) | color=<%= remaining_time_colour %> <%= copy_menu_text_params(vm[:fqdn]) %>
 -- Action | <%= submenu_header_params %>
 -- SSH to VM | href='ssh://root@<%= vm[:fqdn] %>' <%= terminal_action_params %>
 -- Delete VM | bash=<%= this_script %> param1=delete param2=<%= vm[:hostname] %> <%= refresh_action_params %>
@@ -127,11 +127,15 @@ EOS
               vm[:lifetime] = details['lifetime']
               vm[:running] = details['running']
               vm[:remaining] = vm[:lifetime] - vm[:running]
+              vm[:name] = vm[:template]
 
               expiring_soon = expiring_soon || vm[:remaining] <= warning_timeleft_threshhold ? true : false
 
               next unless details.key?('tags')
               vm[:tags] = details['tags']
+              if vm[:tags].key?('name')
+                vm[:name] = vm[:tags]['name']
+              end
             end
           end
           # Sort, newer vms first


### PR DESCRIPTION
This commit checks if the `name` tag has been set in vmpooler by beaker, if present it uses that instead of the `template` in the main menu to make finding the machine you want easier.

If a `dashboard` role is detected in the `role` tag then a menu action allowing the user to open PE Console is added.

![screen shot 2016-09-22 at 7 19 27 pm](https://cloud.githubusercontent.com/assets/83862/18760615/bb85edd2-80f9-11e6-841a-292fb7880a8c.png)

See puppetlabs/beaker#1253
