### PR TITLE
(maint) update vmfloaty auth error handling

### DIFF
--- a/vmpooler-bitbar.30s.rb
+++ b/vmpooler-bitbar.30s.rb
@@ -101,10 +101,17 @@ Refresh... | refresh=true
 EOS
 
         # Check connectivity and get running vms
-        status = Auth.token_status(false, vmpooler_url, token)
-        # Needs a tweak to vmfloaty to not exit within Auth lib - pending
-        if status['ok'] == false
-          abort('Unable to connect to vmpooler.\nPlease check that vmfloaty is correctly configured.')
+        begin
+          status = Auth.token_status(false, vmpooler_url, token)
+        rescue TokenError => msg
+          puts '🔥 Token Error',
+               '---',
+               "#{msg}",
+               'Check your ~/.vmfloaty.yml|href=https://github.com/briancain/vmfloaty#vmfloaty-dotfile',
+               'Click for info|href=https://github.com/briancain/vmfloaty#vmfloaty-dotfile',
+               '---',
+               'Refresh... | refresh=true'
+          exit 1
         end
 
         vms = {}

--- a/vmpooler-bitbar.30s.rb
+++ b/vmpooler-bitbar.30s.rb
@@ -6,14 +6,30 @@ require 'vmfloaty/auth'
 require 'vmfloaty/conf'
 require 'vmfloaty/pooler'
 require 'vmfloaty/utils'
+require 'vmfloaty/version'
 
 class VmpoolerBitbar
   include Commander::Methods
+  # Minimum supported vmfloaty version
 
   def run
     program :name, 'vmpooler-bitbar'
     program :version, '1.0.0'
     program :description, 'VMPooler BitBar plugin based on vmfloaty.'
+
+    # Check vmfloaty library version
+    min_vmfloaty_version = '0.7.0'
+    if Gem::Version.new(Version.get) < Gem::Version.new(min_vmfloaty_version)
+      puts '🔥 Update vmfloaty',
+            '---',
+            "Please update vmfloaty to a version > #{min_vmfloaty_version}",
+            "Current version is #{Version.get}",
+            '---',
+            'Refresh... | refresh=true'
+      exit 1
+    end
+
+
 
     config = Conf.read_config
     vmpooler_url = config['url']


### PR DESCRIPTION
This PR updates the auth token error handling following the updates to vmfloaty made in briancain/vmfloaty#33

It also adds a check that the briancain/vmfloaty gem is `>= 0.7.0`.

Tested with an invalid token, no token, also with a vmfloaty version of `0.5.0`.
