### PR TITLE
corrects failure when there are no tags

### DIFF
--- a/vmpooler-bitbar.30s.rb
+++ b/vmpooler-bitbar.30s.rb
@@ -53,7 +53,7 @@ class VmpoolerBitbar
     def get_display_name(vm)
       # list of roles which override the vm[:name] displayed
       flagged_roles = ['vanagon_target']
-      if vm[:tags].key?('roles')
+      if vm[:tags] && vm[:tags].key?('roles')
         flagged_roles.each do | flagged_role |
           if vm[:tags]['roles'].include?(flagged_role)
             return flagged_role


### PR DESCRIPTION
check for tags before checking for roles to prevent failure when there are no tags